### PR TITLE
feat: Latest tonic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tonic-openssl"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Lucio Franco <luciofranco14@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 documentation = "https://docs.rs/tonic-openssl/0.2.0/tonic_openssl"
 repository = "https://github.com/LucioFranco/tonic-openssl"
@@ -19,7 +19,7 @@ members = [
 
 [dependencies]
 tokio = "1"
-tonic = "0.8"
+tonic = "0.12"
 async-stream = "0.3"
 tokio-openssl = "0.6"
 openssl = "0.10"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -2,7 +2,7 @@
 name = "example"
 version = "0.1.0"
 authors = ["Lucio Franco <luciofranco14@gmail.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [[bin]]
@@ -18,16 +18,17 @@ name = "server"
 path = "src/server.rs"
 
 [dependencies]
-tonic = "0.8"
-tonic-openssl = { version = "0.2", path = ".." }
-hyper = "0.14"
-hyper-openssl = "0.9"
-prost = "0.11"
+tonic = "0.12"
+tonic-openssl = { version = "0.3", path = ".." }
+hyper = { version = "1.0", features = ["http1", "http2"] }
+hyper-openssl = { version = "0.10", features = ["client-legacy"] }
+prost = "0.13"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 openssl = "0.10"
-tower = "0.4"
+tower = "0.5"
 pretty_env_logger = "*"
+hyper-util = { version = "0.1.9", features = ["client-legacy", "http1", "http2"] }
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build = "0.12"

--- a/example/src/client.rs
+++ b/example/src/client.rs
@@ -1,7 +1,8 @@
 use hello_world::greeter_client::GreeterClient;
 use hello_world::HelloRequest;
-use hyper::{client::connect::HttpConnector, Client, Uri};
-use hyper_openssl::HttpsConnector;
+use hyper::Uri;
+use hyper_util::{client::legacy::{connect::HttpConnector, Client}, rt::TokioExecutor};
+use hyper_openssl::client::legacy::HttpsConnector;
 use openssl::{
     ssl::{SslConnector, SslMethod},
     x509::X509,
@@ -37,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Configure hyper's client to be h2 only and build with the
     // correct https connector.
-    let hyper = Client::builder().http2_only(true).build(https);
+    let hyper = Client::builder(TokioExecutor::new()).http2_only(true).build(https);
 
     let uri = Uri::from_static("https://[::1]:50051");
 

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -1,0 +1,42 @@
+/// Represents a X509 certificate.
+#[derive(Debug, Clone)]
+pub struct Certificate {
+    pub(crate) pem: Vec<u8>,
+}
+
+impl Certificate {
+    /// Parse a PEM encoded X509 Certificate.
+    ///
+    /// The provided PEM should include at least one PEM encoded certificate.
+    pub fn from_pem(pem: impl AsRef<[u8]>) -> Self {
+        let pem = pem.as_ref().into();
+        Self { pem }
+    }
+
+    /// Get a immutable reference to underlying certificate
+    pub fn get_ref(&self) -> &[u8] {
+        self.pem.as_slice()
+    }
+
+    /// Get a mutable reference to underlying certificate
+    pub fn get_mut(&mut self) -> &mut [u8] {
+        self.pem.as_mut()
+    }
+
+    /// Consumes `self`, returning the underlying certificate
+    pub fn into_inner(self) -> Vec<u8> {
+        self.pem
+    }
+}
+
+impl AsRef<[u8]> for Certificate {
+    fn as_ref(&self) -> &[u8] {
+        self.pem.as_ref()
+    }
+}
+
+impl AsMut<[u8]> for Certificate {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.pem.as_mut()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,9 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tonic::transport::{server::Connected, Certificate};
+use tonic::transport::server::Connected;
+mod certificate;
+pub use certificate::Certificate;
 
 /// Wrapper error type.
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;


### PR DESCRIPTION
This updates to Tonic 0.12 and hyper 1.0. Right now, it still uses hyper's legacy client in the examples, but it works.

I just copied `src/certificate.rs` from tonic, because tonic now uses that behind the `tls` feature, which would add more deps.

Please let me know if you have a better solution. I did not add the copyright note from Tonic because it's the same as this repo, let me know if I should add additional attribution. 