### PR TITLE
Add client connector and test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ async-stream = "0.3"
 tokio-openssl = "0.6"
 openssl = "0.10"
 futures = { version = "0.3", default-features = false }
+tower = "0.5"
+hyper = "1.5"
+hyper-util = "0.1"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -29,6 +29,11 @@ openssl = "0.10"
 tower = "0.5"
 pretty_env_logger = "*"
 hyper-util = { version = "0.1.9", features = ["client-legacy", "http1", "http2"] }
+tokio-util = "0.7"
 
 [build-dependencies]
 tonic-build = "0.12"
+
+# For protobuf rs code
+[package.metadata.rust-analyzer]
+cargo.loadOutDirsFromCheck = true

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1,0 +1,267 @@
+// Test tonic openssl using example proto
+
+use tonic::{transport::server::TcpConnectInfo, Request, Response, Status};
+use tonic_openssl::SslConnectInfo;
+
+tonic::include_proto!("helloworld");
+
+pub struct MyGreeter {}
+
+#[tonic::async_trait]
+impl crate::greeter_server::Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloReply>, Status> {
+        let remote_addr = request
+            .extensions()
+            .get::<SslConnectInfo<TcpConnectInfo>>()
+            .and_then(|info| info.get_ref().remote_addr());
+        println!("Got a request from {:?}", remote_addr);
+
+        let reply = HelloReply {
+            message: format!("Hello {}!", request.into_inner().name),
+        };
+        Ok(Response::new(reply))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::SocketAddr,
+        path::{Path, PathBuf},
+        time::Duration,
+    };
+
+    use openssl::ssl::{
+        SslAcceptor, SslAcceptorBuilder, SslConnector, SslConnectorBuilder, SslFiletype, SslMethod,
+        SslVerifyMode,
+    };
+    use tokio::net::TcpListener;
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tokio_util::sync::CancellationToken;
+    use tonic::transport::Channel;
+
+    const CERT_DIR: &str = "./tls";
+    const TEST_SUBJECT_NAME: &str = "localhost";
+
+    /// Helper function to set connector with alpn protocol and tls version.
+    pub fn openssl_configure_connector(
+        conn: &mut SslConnectorBuilder,
+    ) -> Result<(), tonic_openssl::Error> {
+        conn.set_alpn_protos(tonic_openssl::ALPN_H2_WIRE)
+            .map_err(tonic_openssl::Error::from)
+    }
+
+    pub fn openssl_configure_acceptor(acceptor: &mut SslAcceptorBuilder) {
+        acceptor.set_alpn_select_callback(|_ssl, alpn| {
+            openssl::ssl::select_next_proto(tonic_openssl::ALPN_H2_WIRE, alpn)
+                .ok_or(openssl::ssl::AlpnError::NOACK)
+        });
+    }
+    // get openssl connector with client cert set.
+    pub fn get_test_openssl_connector<P: AsRef<Path>>(
+        ca_path: P,
+        cert_path: P,
+        key_path: P,
+    ) -> SslConnector {
+        let mut connector = SslConnector::builder(SslMethod::tls()).unwrap();
+        connector.set_ca_file(ca_path.as_ref()).unwrap();
+        connector
+            .set_certificate_file(cert_path.as_ref(), SslFiletype::PEM)
+            .unwrap();
+        connector
+            .set_private_key_file(key_path.as_ref(), SslFiletype::PEM)
+            .unwrap();
+        connector.set_verify_callback(
+            SslVerifyMode::PEER,
+            get_unsafe_verify_callback(TEST_SUBJECT_NAME.to_string()),
+        );
+        openssl_configure_connector(&mut connector).unwrap();
+        connector.build()
+    }
+
+    pub async fn connect_test_tonic_channel(
+        addr: SocketAddr,
+        ca: &Path,
+        cert: &Path,
+        key: &Path,
+    ) -> Result<Channel, tonic::transport::Error> {
+        let connector = get_test_openssl_connector(ca, cert, key);
+        tonic_openssl::new_endpoint()
+            .connect_with_connector(tonic_openssl::connector(
+                format!("https://{}", addr).parse().unwrap(),
+                connector,
+                // test cert has alt subject dns
+                Some(TEST_SUBJECT_NAME.to_string()),
+            ))
+            .await
+    }
+
+    // Run the tonic server on the current thread until token is cancelled.
+    async fn run_tonic_server(
+        token: CancellationToken,
+        listener: TcpListener,
+        ca: &Path,
+        cert: &Path,
+        key: &Path,
+    ) {
+        let greeter = crate::MyGreeter {};
+        // build openssl acceptor
+        let mut acceptor = SslAcceptor::mozilla_intermediate(SslMethod::tls()).unwrap();
+        acceptor
+            .set_private_key_file(key, SslFiletype::PEM)
+            .unwrap();
+        acceptor.set_certificate_chain_file(cert).unwrap();
+        acceptor.set_ca_file(ca).unwrap();
+        acceptor.check_private_key().unwrap();
+        openssl_configure_acceptor(&mut acceptor);
+        // require client to present cert with matching subject name.
+        acceptor.set_verify_callback(
+            SslVerifyMode::PEER | SslVerifyMode::FAIL_IF_NO_PEER_CERT,
+            get_unsafe_verify_callback(TEST_SUBJECT_NAME.to_string()),
+        );
+
+        let acceptor = acceptor.build();
+
+        let incoming = tonic_openssl::incoming(TcpListenerStream::new(listener), acceptor);
+
+        tonic::transport::Server::builder()
+            .add_service(crate::greeter_server::GreeterServer::new(greeter))
+            .serve_with_incoming_shutdown(incoming, async move { token.cancelled().await })
+            .await
+            .unwrap();
+    }
+
+    // creates a listener on a random port from os, and return the addr.
+    pub async fn create_listener_server() -> (tokio::net::TcpListener, std::net::SocketAddr) {
+        let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+        let local_addr = listener.local_addr().unwrap();
+        (listener, local_addr)
+    }
+
+    /// TODO: currently the cert in this repo gives this error: unsupported certificate purpose
+    /// so we blindly accept all certs for now.
+    fn get_unsafe_verify_callback(
+        _subject_name: String,
+    ) -> impl Fn(bool, &mut openssl::x509::X509StoreContextRef) -> bool {
+        move |preverify_ok: bool, ctx: &mut openssl::x509::X509StoreContextRef| {
+            if !preverify_ok {
+                // cert has problem
+                let e = ctx.error();
+                println!("verify failed : {}", e);
+            }
+            true
+        }
+    }
+
+    /// returns the verify callback that checks the subject name matches in the SN field or Alt field.
+    /// This is only an example of how to do validation with self signed certs.
+    /// TODO: use this one.
+    #[allow(dead_code)]
+    fn get_sn_verify_callback(
+        subject_name: String,
+    ) -> impl Fn(bool, &mut openssl::x509::X509StoreContextRef) -> bool {
+        move |preverify_ok: bool, ctx: &mut openssl::x509::X509StoreContextRef| {
+            if !preverify_ok {
+                // cert has problem
+                let e = ctx.error();
+                println!("verify failed : {}", e);
+                return false;
+            }
+
+            // further check subject name.
+            let ch = ctx.chain();
+            if ch.is_none() {
+                return false;
+            }
+            let ch = ch.unwrap();
+            let leaf = ch.iter().last();
+            if leaf.is_none() {
+                return false;
+            }
+            let leaf = leaf.unwrap();
+            let sn = leaf.subject_name();
+            let sn_ok = sn.entries().any(|e| {
+                let name = String::from_utf8_lossy(e.data().as_slice());
+                println!("sn: {}", name);
+                name == subject_name
+            });
+            if sn_ok {
+                return true;
+            }
+            // sn does not match, so we try to match alt names
+            let alt = leaf.subject_alt_names();
+            let alt_ok = match alt {
+                Some(alts) => alts.into_iter().any(|n| match n.dnsname() {
+                    Some(dns) => {
+                        println!("alt dns: {}", dns);
+                        dns == subject_name
+                    }
+                    None => false,
+                }),
+                None => false,
+            };
+            return alt_ok;
+        }
+    }
+
+    #[tokio::test]
+    async fn basic() {
+        let test_ca = PathBuf::from(CERT_DIR).join("ca.pem");
+        let test_cert = PathBuf::from(CERT_DIR).join("server.pem");
+        let test_key = PathBuf::from(CERT_DIR).join("server.key");
+
+        let test_ca_cp = test_ca.clone();
+        let test_cert_cp = test_cert.clone();
+        let test_key_cp = test_key.clone();
+
+        // get a random port on localhost from os
+        let (listener, addr) = create_listener_server().await;
+
+        let sv_token = CancellationToken::new();
+        let sv_token_cp = sv_token.clone();
+        // start server in background
+        let sv_h = tokio::spawn(async move {
+            run_tonic_server(sv_token_cp, listener, &test_ca, &test_cert, &test_key).await
+        });
+
+        println!("running server on {addr}");
+
+        // wait a bit for server to boot up.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // TODO: enable this once the failure check is upstreamed.
+        // send a request with a wrong cert and verify it fails
+        // {
+        //     let e = connect_test_tonic_channel(addr, &test_ca, &test_cert, &test_key)
+        //         .await
+        //         .expect_err("unexpected success");
+        //     // there is a double wrappring of the error of ssl Error
+        //     let src = e.source().unwrap().source().unwrap();
+        //     let ssl_e = src.downcast_ref::<openssl::ssl::Error>().unwrap();
+        //     // Check generic ssl error. The detail of the error should be server cert untrusted, which is unimportant,
+        //     // since the test case here only aims to cause an ssl failure between client and server.
+        //     assert_eq!(ssl_e.code(), openssl::ssl::ErrorCode::SSL);
+        //     let inner_e = ssl_e.ssl_error().unwrap().errors();
+        //     assert_eq!(inner_e.len(), 1);
+        // }
+
+        // get client and send request
+        let ch = connect_test_tonic_channel(addr, &test_ca_cp, &test_cert_cp, &test_key_cp)
+            .await
+            .unwrap();
+        let mut client = crate::greeter_client::GreeterClient::new(ch);
+        let request = tonic::Request::new(crate::HelloRequest {
+            name: "Tonic".into(),
+        });
+        let resp = client.say_hello(request).await.unwrap();
+        println!("RESPONSE={:?}", resp);
+
+        // stop server
+        sv_token.cancel();
+        sv_h.await.unwrap();
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,103 @@
+//! Client connection helpers
+
+use std::net::SocketAddr;
+
+use openssl::ssl::SslConnector;
+use tokio::net::TcpStream;
+use tonic::transport::{Endpoint, Uri};
+use tower::Service;
+
+/// Creates an endpoint with and local uri that is never used.
+/// Use `connector` to make connections.
+pub fn new_endpoint() -> Endpoint {
+    tonic::transport::Endpoint::from_static("http://[::]:50051")
+}
+
+/// tonic client connector to connect to https endpoint at addr using
+/// openssl settings in ssl.
+/// domain is the server name to validate, and if none, the host part in the uri
+/// is used instead. Disabling validation is not supported.
+/// # Examples
+/// ```
+/// use openssl::ssl::SslMethod;
+/// use openssl::ssl::SslConnector;
+/// async fn example(){
+///     let connector = SslConnector::builder(SslMethod::tls()).unwrap().build();
+///     let ch: tonic::transport::Channel= tonic_openssl::new_endpoint()
+///         .connect_with_connector(tonic_openssl::connector(
+///             "https:://localhost:12345".parse().unwrap(),
+///             connector,
+///            Some("localhost".to_string()),
+///         ))
+///         .await.unwrap();
+/// }
+/// ```
+pub fn connector(
+    uri: Uri,
+    ssl_conn: SslConnector,
+    domain: Option<String>,
+) -> impl Service<
+    Uri,
+    Response = impl hyper::rt::Read + hyper::rt::Write + Send + Unpin + 'static,
+    Future = impl Send + 'static,
+    Error = crate::Error,
+> {
+    tower::service_fn(move |_: Uri| {
+        let domain = domain.clone();
+        let uri = uri.clone();
+        let ssl_conn = ssl_conn.clone();
+        async move {
+            let addrs = dns_resolve(&uri).await?;
+            let ssl_config = ssl_conn.configure()?;
+
+            let ssl = match domain {
+                Some(d) => {
+                    // configure server name check.
+                    ssl_config.into_ssl(&d)?
+                }
+                // use the host part in the uri to do server name check.
+                // unwrap should not panic since the above uri to addr passed.
+                None => ssl_config.into_ssl(uri.host().unwrap())?,
+            };
+            // Connect and get ssl stream
+            let io = connect_tcp(addrs).await?;
+            let mut stream = tokio_openssl::SslStream::new(ssl, io)?;
+            std::pin::Pin::new(&mut stream).connect().await?;
+            Ok::<_, crate::Error>(hyper_util::rt::TokioIo::new(stream))
+        }
+    })
+}
+
+/// Use the host:port portion of the uri and resolve to an sockaddr.
+/// If uri host portion is an ip string, then directly use the ip addr without
+/// dns lookup.
+async fn dns_resolve(uri: &Uri) -> std::io::Result<Vec<SocketAddr>> {
+    let host_port = uri
+        .authority()
+        .ok_or(std::io::Error::from(std::io::ErrorKind::InvalidInput))?
+        .as_str();
+    match host_port.parse::<SocketAddr>() {
+        Ok(addr) => Ok(vec![addr]),
+        Err(_) => {
+            // uri is using a dns name. try resolve it and return the first.
+            tokio::net::lookup_host(host_port)
+                .await
+                .map(|a| a.collect::<Vec<_>>())
+        }
+    }
+}
+
+/// Connect to the target addr (from the same dns). The first success SockAddr connection
+/// stream is returned. This is needed because sometimes ipv4 or ipv6 addrs are returned
+/// by dns resolution, and only 1 of them works, especially in docker. This is the
+/// same logic in hyper client.
+async fn connect_tcp(addrs: Vec<SocketAddr>) -> std::io::Result<TcpStream> {
+    let mut conn_err = std::io::Error::from(std::io::ErrorKind::AddrNotAvailable);
+    for addr in addrs {
+        match TcpStream::connect(addr).await {
+            Ok(s) => return Ok(s),
+            Err(e) => conn_err = e,
+        }
+    }
+    Err(conn_err)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@
     unreachable_pub
 )]
 
+mod client;
+pub use client::{connector, new_endpoint};
+
 use async_stream::try_stream;
 use futures::{Stream, TryStream, TryStreamExt};
 use openssl::{


### PR DESCRIPTION
Add client connector for building Channel, using Endpoint::connect_with_connector.
Add server-client test using existing certs in this repo.