### PR TITLE
Superceded by tonic-tls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**tonic-openssl is superceded by [tonic-tls](https://github.com/youyuanwu/tonic-tls) which has richer features.**
+
 # tonic-openssl
 
 A wrapper crate for OpenSSL and `tonic`.


### PR DESCRIPTION
Updated readme to point to [tonic-tls](https://github.com/youyuanwu/tonic-tls).
tonic-tls contains all the features this crate has, but has other features as well. I plan to maintain tonic-tls from now on.